### PR TITLE
Speed up News and Events page feel by using native scrolling

### DIFF
--- a/aem-package/content-dev/src/main/content/jcr_root/apps/hybrid-reference-app/components/ionic-app-news-page/template.html
+++ b/aem-package/content-dev/src/main/content/jcr_root/apps/hybrid-reference-app/components/ionic-app-news-page/template.html
@@ -1,6 +1,6 @@
 <div data-sly-use.newsHelper="${ 'com.adobe.ionicapp.sly.NewsHelper' @ page=resourcePage }" data-sly-unwrap>
 <ion-view view-title="${properties.jcr:title}">
-	<ion-content class="news" style="background-image: url('${newsHelper.backgroundPath @ context='html'}');">
+	<ion-content overflow-scroll="true" class="news" style="background-image: url('${newsHelper.backgroundPath @ context='html'}');">
         <div class="articles">
             <div data-sly-resource="${ @path='content-par', resourceType='foundation/components/parsys' }" data-sly-unwrap></div>
         </div>


### PR DESCRIPTION
I was able to cut the number of dropped frames in half (from 23 to ~10) by using native scrolling on the news page. For test results on iOS, check out: https://docs.google.com/spreadsheets/d/1ajy6W0PWtDniy-sB8tGqetlhQd_R3NBRbCOCggxfuZQ/edit?usp=sharing
